### PR TITLE
Add Dockerfile to test building in controlled way

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM ubuntu:23.04
+FROM python:3.9
 
 WORKDIR /data
 
-RUN apt-get update && apt-get install -y python3-pip python3-virtualenv python3-dev build-essential pkg-config git ninja-build meson python3-sphinx
-RUN virtualenv /data/
-ENV PATH="/data/bin:$PATH"
-RUN /data/bin/pip install Cython 
+RUN apt-get update && apt-get install -y build-essential pkg-config git ninja-build meson
 
+# First install serd-1
+RUN git clone --branch 1.x https://github.com/drobilla/serd.git
+RUN cd serd && meson setup build && cd build && meson compile && meson install && cd /data
 COPY . .
-
-RUN meson setup builddir && ninja -C builddir 
+RUN pip install Cython
+RUN CYTHONIZE=1 pip install .
+# If you don't run ldconfig, the lib is not found, see https://github.com/drobilla/serd/issues/15

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:23.04
+
+WORKDIR /data
+
+RUN apt-get update && apt-get install -y python3-pip python3-virtualenv python3-dev build-essential pkg-config git ninja-build meson python3-sphinx
+RUN virtualenv /data/
+ENV PATH="/data/bin:$PATH"
+RUN /data/bin/pip install Cython 
+
+COPY . .
+
+RUN meson setup builddir && ninja -C builddir 


### PR DESCRIPTION
Hi @drobilla 

Thanks for sharing your library. I am hoping that it can be used to do some performant triple munging from Python, specifically for fixing things like malformed unescaped URIs in upstream data dumps.

Testing compilation, I get an error message:

```shell
7.871 [265/267] Generating serd.c with a custom command
7.871 FAILED: serd.c 
7.871 /data/bin/cython -3 --fast-fail -Wextra ../serd.pyx -o serd.c
7.871 warning: /data/serd.pyx:2475:35: Unknown type declaration 'uint' in annotation, ignoring
7.871 warning: /data/serd.pyx:2475:50: Unknown type declaration 'uint' in annotation, ignoring
7.871 
7.871 Error compiling Cython file:
7.871 ------------------------------------------------------------
7.871 ...
7.871     def __init__(self: Sink, world: World, func: callable = None):
7.871         if func is not None:
7.871             self._parent = world
7.871             self._env = Env(world)
7.871             self._func = func
7.871             self._ptr = serd_sink_new(NULL, <void*>self, Sink._c_on_event, NULL)
7.871                                                              ^
7.871 ------------------------------------------------------------
7.871 
7.871 /data/serd.pyx:2747:61: Cannot assign type 'SerdStatus (void *, const SerdEvent *) except *' to 'SerdEventFunc'
7.871 ninja: build stopped: subcommand failed.
```

Here is a Dockerfile that can be used for testing builds.

My C-fu is too weak to debug this one, do you have any suggestions on how to fix this build error please?

regards

@epoz
